### PR TITLE
fix: apply thrust at the center of multiblocks

### DIFF
--- a/src/main/java/dev/propulsionteam/propulsionsimulated/content/thruster/ThrusterForceProvider.java
+++ b/src/main/java/dev/propulsionteam/propulsionsimulated/content/thruster/ThrusterForceProvider.java
@@ -1,6 +1,7 @@
 package dev.propulsionteam.propulsionsimulated.content.thruster;
 
 import dev.propulsionteam.propulsionsimulated.PropulsionConfig;
+import net.minecraft.core.BlockPos;
 import org.joml.Vector3d;
 
 public final class ThrusterForceProvider {
@@ -9,10 +10,15 @@ public final class ThrusterForceProvider {
 
     public static ForceSample createSample(final AbstractThrusterBlockEntity blockEntity, final double timeStep) {
         final Vector3d directionLocal = new Vector3d(blockEntity.getThrustDirectionLocal()).normalize();
+        
+        final BlockPos thrusterCenter = blockEntity.isController() ? blockEntity.getBlockPos() : blockEntity.controllerPos;
+        final double thrusterWidth = blockEntity.isMultiblock() ? blockEntity.width : 1.0d;
+        final double offset = thrusterWidth / 2.0d;
+
         final Vector3d applicationPoint = new Vector3d(
-                blockEntity.getBlockPos().getX() + 0.5d,
-                blockEntity.getBlockPos().getY() + 0.5d,
-                blockEntity.getBlockPos().getZ() + 0.5d
+                thrusterCenter.getX() + offset,
+                thrusterCenter.getY() + offset,
+                thrusterCenter.getZ() + offset
         ).fma(PropulsionConfig.NOZZLE_OFFSET_FROM_CENTER.get(), directionLocal);
 
         final Vector3d impulseLocal = new Vector3d(directionLocal).mul(blockEntity.getCurrentThrust() * timeStep);


### PR DESCRIPTION
When using multiblock thrusters, I realized that the force was being applied at one of the corners of the multiblock. This isn't coherent with single thrusters having their center of force at the center of the block, so I fixed it for multiblocks.